### PR TITLE
Refactor packages for clearer architecture

### DIFF
--- a/src/main/java/core/model/FilesDataMap.java
+++ b/src/main/java/core/model/FilesDataMap.java
@@ -1,4 +1,4 @@
-package core.contentManager;
+package core.model;
 
 import java.nio.file.Path;
 import java.util.*;

--- a/src/main/java/core/model/FolderData.java
+++ b/src/main/java/core/model/FolderData.java
@@ -1,4 +1,4 @@
-package core.contentManager;
+package core.model;
 
 import java.nio.file.Path;
 import java.util.HashSet;

--- a/src/main/java/core/model/FolderEntry.java
+++ b/src/main/java/core/model/FolderEntry.java
@@ -1,4 +1,4 @@
-package core.contentManager;
+package core.model;
 
 import java.io.File;
 

--- a/src/main/java/core/model/FolderUtil.java
+++ b/src/main/java/core/model/FolderUtil.java
@@ -1,4 +1,4 @@
-package core.contentManager;
+package core.model;
 
 public class FolderUtil {
 

--- a/src/main/java/core/model/MediaData.java
+++ b/src/main/java/core/model/MediaData.java
@@ -1,5 +1,6 @@
-package core.contentManager;
+package core.model;
 
+import core.service.FileDataProcessor;
 
 import java.nio.file.Path;
 import java.util.*;

--- a/src/main/java/core/service/CollectionNameGenerator.java
+++ b/src/main/java/core/service/CollectionNameGenerator.java
@@ -1,4 +1,4 @@
-package core.contentManager;
+package core.service;
 
 public class CollectionNameGenerator {  /// Этот класс отвечает за автоматическую генерацию имени коллекции на основе данных
 

--- a/src/main/java/core/service/FileDataProcessor.java
+++ b/src/main/java/core/service/FileDataProcessor.java
@@ -1,12 +1,16 @@
-package core.contentManager;
+package core.service;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 
-import static core.contentManager.FolderUtil.getExtension;
-import static core.contentManager.FolderUtil.getName;
+import core.model.FilesDataMap;
+import core.model.FolderData;
+import core.model.MediaData;
+
+import static core.model.FolderUtil.getExtension;
+import static core.model.FolderUtil.getName;
 
 public class FileDataProcessor {
     private static final Set<String> AUDIO_EXTENSIONS = new HashSet<>(Arrays.asList("wav", "flac", "opus", "mp3"));

--- a/src/main/java/core/service/FolderEntities.java
+++ b/src/main/java/core/service/FolderEntities.java
@@ -1,4 +1,4 @@
-package core.contentManager;
+package core.service;
 
 import javax.swing.*;
 import java.nio.file.Path;

--- a/src/main/java/core/service/TransferableManageData.java
+++ b/src/main/java/core/service/TransferableManageData.java
@@ -1,6 +1,8 @@
-package core.contentManager;
+package core.service;
 
-import swing.objects.objects.DataManager;
+import core.model.MediaData;
+
+import swing.util.DataManager;
 import swing.ui.pages.home.play.view.ManagePanel;
 import swing.ui.pages.home.play.view.selection.SelectablePanel;
 

--- a/src/main/java/swing/objects/core/Axis.java
+++ b/src/main/java/swing/objects/core/Axis.java
@@ -1,6 +1,6 @@
 package swing.objects.core;
 
-import swing.objects.objects.WrapLayout;
+import swing.util.WrapLayout;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/swing/objects/core/PanelType.java
+++ b/src/main/java/swing/objects/core/PanelType.java
@@ -1,6 +1,6 @@
 package swing.objects.core;
 
-import swing.objects.objects.WrapLayout;
+import swing.util.WrapLayout;
 
 import java.awt.*;
 

--- a/src/main/java/swing/objects/dropper/DropPanelAbstract.java
+++ b/src/main/java/swing/objects/dropper/DropPanelAbstract.java
@@ -1,6 +1,6 @@
 package swing.objects.dropper;
 
-import core.contentManager.TransferableManageData;
+import core.service.TransferableManageData;
 import swing.ui.pages.home.collections.objects.CollectionObject;
 
 public abstract class DropPanelAbstract {

--- a/src/main/java/swing/ui/pages/home/collections/CollectionsPanel.java
+++ b/src/main/java/swing/ui/pages/home/collections/CollectionsPanel.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.home.collections;
 
 import swing.objects.core.JPanelCustom;
-import swing.objects.objects.SmoothScrollPane;
+import swing.util.SmoothScrollPane;
 import swing.ui.pages.home.collections.objects.CollectionObjectPanel;
 
 import java.awt.*;

--- a/src/main/java/swing/ui/pages/home/collections/droppers/DropTargetNewCollection.java
+++ b/src/main/java/swing/ui/pages/home/collections/droppers/DropTargetNewCollection.java
@@ -1,8 +1,8 @@
 package swing.ui.pages.home.collections.droppers;
 
-import core.contentManager.MediaData;
+import core.model.MediaData;
 import swing.objects.dropper.DropPanelAbstract;
-import core.contentManager.TransferableManageData;
+import core.service.TransferableManageData;
 import swing.ui.pages.home.collections.objects.CollectionObjectPanel;
 
 import java.util.List;

--- a/src/main/java/swing/ui/pages/home/collections/objects/CollectionManager.java
+++ b/src/main/java/swing/ui/pages/home/collections/objects/CollectionManager.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.home.collections.objects;
 
-import core.contentManager.CollectionNameGenerator;
-import core.contentManager.MediaData;
+import core.service.CollectionNameGenerator;
+import core.model.MediaData;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/swing/ui/pages/home/play/view/CombinedPanel.java
+++ b/src/main/java/swing/ui/pages/home/play/view/CombinedPanel.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.home.play.view;
 
 import swing.objects.core.JPanelCustom;
-import swing.objects.objects.ViewCardLayout;
+import swing.util.ViewCardLayout;
 
 import java.awt.*;
 

--- a/src/main/java/swing/ui/pages/home/play/view/ManagePanel.java
+++ b/src/main/java/swing/ui/pages/home/play/view/ManagePanel.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.home.play.view;
 
-import core.contentManager.*;
-import swing.objects.objects.PathManager;
+import core.model.FilesDataMap;
+import swing.util.PathManager;
 import swing.objects.core.Axis;
 import swing.objects.core.JPanelCustom;
 import swing.ui.pages.home.play.view.controllers.DragGlassPane;

--- a/src/main/java/swing/ui/pages/home/play/view/SelectionMenuPanel.java
+++ b/src/main/java/swing/ui/pages/home/play/view/SelectionMenuPanel.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.home.play.view;
 
 import swing.objects.core.JPanelCustom;
-import swing.objects.objects.PathManager;
+import swing.util.PathManager;
 import swing.objects.core.PanelType;
 
 import javax.swing.*;

--- a/src/main/java/swing/ui/pages/home/play/view/controllers/KeyBindingConfigurator.java
+++ b/src/main/java/swing/ui/pages/home/play/view/controllers/KeyBindingConfigurator.java
@@ -1,6 +1,6 @@
 package swing.ui.pages.home.play.view.controllers;
 
-import swing.objects.objects.PathManager;
+import swing.util.PathManager;
 import swing.ui.pages.home.play.view.ManagePanel;
 import swing.ui.pages.home.play.view.selection.SelectablePanel;
 

--- a/src/main/java/swing/ui/pages/home/play/view/controllers/MovementHandler.java
+++ b/src/main/java/swing/ui/pages/home/play/view/controllers/MovementHandler.java
@@ -2,7 +2,7 @@ package swing.ui.pages.home.play.view.controllers;
 
 import swing.objects.dropper.DropPanel;
 import swing.objects.dropper.DropPanelRegistry;
-import core.contentManager.TransferableManageData;
+import core.service.TransferableManageData;
 import swing.ui.pages.home.SwingHomeVariables;
 import swing.ui.pages.home.collections.BottomAddCollectionPanel;
 import swing.ui.pages.home.collections.EmptyDropPanel;

--- a/src/main/java/swing/ui/pages/home/play/view/selection/SelectablePanel.java
+++ b/src/main/java/swing/ui/pages/home/play/view/selection/SelectablePanel.java
@@ -1,8 +1,8 @@
 package swing.ui.pages.home.play.view.selection;
 
-import core.contentManager.FilesDataMap;
-import core.contentManager.MediaData;
-import swing.objects.objects.PathManager;
+import core.model.FilesDataMap;
+import core.model.MediaData;
+import swing.util.PathManager;
 import swing.objects.core.JPanelCustom;
 import swing.ui.pages.home.play.view.controllers.MovementHandler;
 

--- a/src/main/java/swing/ui/pages/home/play/view/selection/SelectionPanel.java
+++ b/src/main/java/swing/ui/pages/home/play/view/selection/SelectionPanel.java
@@ -1,11 +1,11 @@
 package swing.ui.pages.home.play.view.selection;
 
-import core.contentManager.FilesDataMap;
-import core.contentManager.MediaData;
+import core.model.FilesDataMap;
+import core.model.MediaData;
 import swing.objects.core.JPanelCustom;
 import swing.objects.core.PanelType;
-import swing.objects.objects.SmoothScrollPane;
-import swing.objects.objects.Separator;
+import swing.util.SmoothScrollPane;
+import swing.util.Separator;
 import swing.ui.pages.home.play.view.ManagePanel;
 
 import javax.swing.*;

--- a/src/main/java/swing/ui/pages/home/series/DropTargetSeries.java
+++ b/src/main/java/swing/ui/pages/home/series/DropTargetSeries.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.home.series;
 
 import swing.objects.dropper.DropPanelAbstract;
-import core.contentManager.TransferableManageData;
+import core.service.TransferableManageData;
 import swing.ui.pages.home.play.view.selection.SelectablePanel;
 
 import javax.swing.*;

--- a/src/main/java/swing/ui/pages/settings/FolderPathsPanel.java
+++ b/src/main/java/swing/ui/pages/settings/FolderPathsPanel.java
@@ -1,7 +1,7 @@
 package swing.ui.pages.settings;
 
-import core.contentManager.FolderEntities;
-import core.contentManager.FolderEntry;
+import core.service.FolderEntities;
+import core.model.FolderEntry;
 import swing.objects.core.JPanelCustom;
 
 import javax.swing.*;

--- a/src/main/java/swing/util/DataManager.java
+++ b/src/main/java/swing/util/DataManager.java
@@ -1,8 +1,8 @@
-package swing.objects.objects;
+package swing.util;
 
-import core.contentManager.FileDataProcessor;
-import core.contentManager.FilesDataMap;
-import core.contentManager.FolderEntities;
+import core.service.FileDataProcessor;
+import core.model.FilesDataMap;
+import core.service.FolderEntities;
 
 public class DataManager {
     private static final DataManager INSTANCE = new DataManager();

--- a/src/main/java/swing/util/PathManager.java
+++ b/src/main/java/swing/util/PathManager.java
@@ -1,4 +1,4 @@
-package swing.objects.objects;
+package swing.util;
 
 import swing.ui.pages.home.play.view.ManagePanel;
 

--- a/src/main/java/swing/util/Separator.java
+++ b/src/main/java/swing/util/Separator.java
@@ -1,4 +1,4 @@
-package swing.objects.objects;
+package swing.util;
 
 import java.awt.*;
 import javax.swing.*;

--- a/src/main/java/swing/util/SmoothScrollPane.java
+++ b/src/main/java/swing/util/SmoothScrollPane.java
@@ -1,4 +1,4 @@
-package swing.objects.objects;
+package swing.util;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/swing/util/ViewCardLayout.java
+++ b/src/main/java/swing/util/ViewCardLayout.java
@@ -1,8 +1,8 @@
-package swing.objects.objects;
+package swing.util;
 
-import core.contentManager.FileDataProcessor;
-import core.contentManager.FilesDataMap;
-import core.contentManager.FolderEntities;
+import core.service.FileDataProcessor;
+import core.model.FilesDataMap;
+import core.service.FolderEntities;
 import swing.ui.pages.home.play.view.CombinedPanel;
 import swing.ui.pages.home.play.view.ManagePanel;
 

--- a/src/main/java/swing/util/WrapLayout.java
+++ b/src/main/java/swing/util/WrapLayout.java
@@ -1,4 +1,4 @@
-package swing.objects.objects;
+package swing.util;
 
 import java.awt.*;
 import javax.swing.*;


### PR DESCRIPTION
## Summary
- regroup content manager classes under `core.model` and `core.service`
- move common Swing utilities into `swing.util`
- update imports to use the new packages

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68409fd5296c8328be254f4688de06ed